### PR TITLE
Proposal for "information_uri"

### DIFF
--- a/openid-federation-subordinate-events-1_0.md
+++ b/openid-federation-subordinate-events-1_0.md
@@ -132,7 +132,7 @@ The claims in the Subordinate events statement response are:
 - **iat**: (REQUIRED) Time when the event is related to, using the time format defined for the `iat` claim.
 - **event**: (REQUIRED) String that identifies the event, such as `registration`, `jwks_update`, `metadata_policy_update`, `metadata_update`, or `revocation`.
 - **event_description**: (OPTIONAL) String that may offer additional information about the event.
-- **information_uri**: (OPTIONAL) URI that may offer additional information about the event.
+- **information_uri**: (OPTIONAL) URI that may offer additional information about the event. Use of HTTPs URLs is RECOMMENDED.
 
 #### Example Response
 

--- a/openid-federation-subordinate-events-1_0.md
+++ b/openid-federation-subordinate-events-1_0.md
@@ -132,7 +132,7 @@ The claims in the Subordinate events statement response are:
 - **iat**: (REQUIRED) Time when the event is related to, using the time format defined for the `iat` claim.
 - **event**: (REQUIRED) String that identifies the event, such as `registration`, `jwks_update`, `metadata_policy_update`, `metadata_update`, or `revocation`.
 - **event_description**: (OPTIONAL) String that may offer additional information about the event.
-- **information_uri**: (OPTIONAL) URI that may offer additional information about the event. Use of HTTPs URLs is RECOMMENDED.
+- **information_uri**: (OPTIONAL) URI that may offer additional, human readable, information about the event. Use of HTTPs URLs is RECOMMENDED.
 
 #### Example Response
 

--- a/openid-federation-subordinate-events-1_0.md
+++ b/openid-federation-subordinate-events-1_0.md
@@ -132,6 +132,7 @@ The claims in the Subordinate events statement response are:
 - **iat**: (REQUIRED) Time when the event is related to, using the time format defined for the `iat` claim.
 - **event**: (REQUIRED) String that identifies the event, such as `registration`, `jwks_update`, `metadata_policy_update`, `metadata_update`, or `revocation`.
 - **event_description**: (OPTIONAL) String that may offer additional information about the event.
+- **information_uri**: (OPTIONAL) URI that may offer additional information about the event.
 
 #### Example Response
 
@@ -143,7 +144,8 @@ The claims in the Subordinate events statement response are:
   "federation_registration_events": [
     {
       "iat": 1590000000,
-      "event": "registration"
+      "event": "registration",
+      "information_uri" : "https://immediate-superior.example.org/policy/Metadata+Registration+Practice+Statement"
     },
     {
       "iat": 1590000000,
@@ -152,7 +154,8 @@ The claims in the Subordinate events statement response are:
     {
       "iat": 1600000000,
       "event": "revocation",
-      "event_description": "compromised node"
+      "event_description": "compromised node",
+      "information_uri" : "https://www.cve.org/CVERecord?id=CVE-2018-1000611"
     },
     {
       "iat": 1610000000,

--- a/openid-federation-subordinate-events-1_0.md
+++ b/openid-federation-subordinate-events-1_0.md
@@ -145,7 +145,7 @@ The claims in the Subordinate events statement response are:
     {
       "iat": 1590000000,
       "event": "registration",
-      "information_uri" : "https://immediate-superior.example.org/policy/Metadata+Registration+Practice+Statement"
+      "information_uri" : "https://immediate-superior.example.org/policy/Metadata_Registration_Practice_Statement"
     },
     {
       "iat": 1590000000,

--- a/openid-federation-subordinate-events-1_0.md
+++ b/openid-federation-subordinate-events-1_0.md
@@ -132,7 +132,7 @@ The claims in the Subordinate events statement response are:
 - **iat**: (REQUIRED) Time when the event is related to, using the time format defined for the `iat` claim.
 - **event**: (REQUIRED) String that identifies the event, such as `registration`, `jwks_update`, `metadata_policy_update`, `metadata_update`, or `revocation`.
 - **event_description**: (OPTIONAL) String that may offer additional information about the event.
-- **information_uri**: (OPTIONAL) URI that may offer additional, human readable, information about the event. Use of HTTPs URLs is RECOMMENDED.
+- **information_uri**: (OPTIONAL) URL for documentation of additional information about this event viewable by the End-User. Use of HTTPs URLs is RECOMMENDED.
 
 #### Example Response
 


### PR DESCRIPTION
I would like to propose to add a way to provide addition information about the event via a URI. Two real world usecases for this:
- Publishing metadata registration policy for a registration event
In R&E SAML federations this is a common way to signal what the policy context of the registration entails, see e.g.: [[Metadata Registration Practice Statement for SURFconext](https://servicedesk.surf.nl/wiki/spaces/IAM/pages/128910076/Metadata+Registration+Practice+Statement+for+SURFconext)](https://servicedesk.surf.nl/wiki/spaces/IAM/pages/128910076/Metadata+Registration+Practice+Statement+for+SURFconext) or [InCommon Metadata Registration Practice Statement](https://incommon.org/federation/mrps/))
- Providing addition information in case of security incidents, like e.g. a link to the relevant CVE

I added proposal for "information_uri": an  (OPTIONAL) URI that may offer additional information about the event, to the "Event Object Parameters" section and also added two examples based on the use cases above in the example